### PR TITLE
fix: prevent null auth header

### DIFF
--- a/src/api/axiosClient.jsx
+++ b/src/api/axiosClient.jsx
@@ -8,8 +8,16 @@ const axiosClient = axios.create({
 
 axiosClient.interceptors.request.use(
   (config) => {
-    const token = JSON.parse(localStorage.getItem("token"));
-    config.headers.Authorization = `Bearer ${token}`;
+    let token;
+    try {
+      token = JSON.parse(localStorage.getItem("token"));
+    } catch {
+      token = null;
+    }
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     if (config.data instanceof FormData) {
       config.headers["Content-Type"] = "multipart/form-data";
     } else {


### PR DESCRIPTION
## Summary
- ensure axios client only sends Authorization header when a valid token is present

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prop-types errors in unrelated files)*
- `npx eslint src/api/axiosClient.jsx`


------
https://chatgpt.com/codex/tasks/task_b_689c15698d6c8328ba033312b04cb5b7